### PR TITLE
4 ability to download plot with efficiency front

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,6 +30,7 @@ Imports:
 Suggests:
     rmarkdown,
     knitr,
+    scales,
     rlang
 Language: en-GB
 Encoding: UTF-8

--- a/inst/app/.gitignore
+++ b/inst/app/.gitignore
@@ -1,0 +1,1 @@
+shiny_bookmarks

--- a/inst/app/R/utils.R
+++ b/inst/app/R/utils.R
@@ -27,14 +27,81 @@ dropdown_button <- function(
     class = 'btn-group', class = direction,
     tags$button(
       class = sprintf('dropdown-toggle btn btn-%s%s', outline, color), class = size,
-      type = 'button', `data-toggle` = 'dropdown', `aria-haspopup` = 'true',
+      `data-bs-auto-close` = if (autoclose) 'true' else 'outside',
+      `data-bs-toggle` = 'dropdown', `aria-haspopup` = 'true',
       `aria-expanded` = 'false', title
     ),
     div(
       class = 'dropdown-menu p-3',
-      `data-autoclose` = if (autoclose) 'true' else 'false',
       style = sprintf('width: %spx; max-width: 90vw;', width),
       div(...))
   )
 
+}
+
+find_scale <- function(x) {
+  m <- max(x)
+  i <- c(1e0, 1e3, 1e6, 1e9, 1e12)
+  x <- c(1e-0, 1e-3, 1e-6, 1e-9, 1e-12)
+  names(i) <- c('', 'K', 'M', 'B', 'T')
+  return(list(names(i)[findInterval(m, i)], x[findInterval(m, i)]))
+}
+
+theme_pioneer <- function(){
+  theme(
+    axis.text.x = element_text(
+      angle = 0, color = '#183271', vjust = 0.5,
+      size = 10
+    ),
+    axis.line.x = element_line('#183271', linetype = 'solid'),
+    axis.text.y = element_text(color = '#183271', size = 10),
+    legend.title = element_blank(),
+    legend.text = element_text(color = '#183271'),
+    plot.margin = unit(c(3,3,2,2), 'lines'),
+    plot.background = element_rect(fill = 'white', color = NA),
+    panel.background = element_rect(fill = 'white', color = NA),
+    panel.grid.major.x = element_line('#183271', linetype = 'dotted'),
+    panel.grid.major.y = element_line('#183271', linetype = 'dotted'),
+    panel.grid.minor.x = element_blank(),
+    panel.grid.minor.y = element_blank(),
+    plot.title = element_text(
+      color = "#183271", face = "bold", size = 15,
+      margin = unit(c(0,0,1,0), "lines")
+    ),
+    axis.ticks.y = element_blank(),
+    axis.ticks.x = element_blank(),
+    axis.title.y =  element_text(
+      size = 12, face = "bold", color = '#183271',
+      margin = unit(c(0,1.5,0,0), "lines")
+    ),
+    axis.title.x =  element_text(
+      size = 12, face = "bold", color = '#183271',
+      margin = unit(c(1.5,0,0,0), "lines")
+    ),
+    legend.background = element_blank(),
+    legend.key = element_rect(fill = "transparent", color = "transparent"),
+    legend.box.background = element_blank(),
+    legend.position = "right",
+    strip.background.x = element_rect(color = "transparent", fill = "transparent"),
+    strip.background.y = element_rect(color = "transparent", fill = "transparent"),
+    strip.text = element_text(
+      color = '#183271', face = "bold", size = 11,
+      margin = unit(c(0,0,1.5,0), "lines")
+    ),
+    panel.spacing = unit(2, "lines"))
+}
+
+ggsave_ <- function(filename, plot, format = 'png', size = c('A5', 'A4', 'A3')) {
+  size <- match.arg(size)
+  dims <- switch(
+    size,
+    A5 = c(210, 148),
+    A4 = c(297, 210),
+    A3 = c(420, 297)
+  )
+  suppressMessages(
+    ggsave(
+      filename, plot, device = format, width = dims[1], height = dims[2],
+      units = 'mm'
+    ))
 }

--- a/inst/app/server.R
+++ b/inst/app/server.R
@@ -6,7 +6,8 @@ require(lpSolveAPI)
 require(lpSolve)
 require(Benchmarking)
 require(productivity)
-require(plotly)
+require(ggplot2)
+require(scales)
 require(haven)
 require(writexl)
 require(reactable)
@@ -66,7 +67,7 @@ shinyServer(function(input, output, session) {
 
   # ---- Data ----
 
-   # Update data when a data file is uploaded
+  # Update data when a data file is uploaded
   observeEvent(input$datafile, {
     dp <- switch(input$data.dec.point, Decimal = ',', Period = '.')
     reactives$data <- fileImport(
@@ -247,63 +248,77 @@ shinyServer(function(input, output, session) {
 
   })
 
-  plot.dea <- reactive({
-
+  dea_plot_df <- reactive({
     req(data(), input$dea.input, input$dea.output)
 
     x <- dea.in()
     y <- dea.out()
 
-    # If `x` is a matrix, we collapse each row to a single value
-    if (is.matrix(x) && dim(x)[2] > 1) {
-      wx <- matrix(1, nrow = dim(x)[2], ncol = 1)
-      x <- x %*% wx
-    }
-    # If `y` is a matrix, we collapse each row to a single value
-    if (is.matrix(y) && dim(y)[2] > 1) {
-      wy <- matrix(1, nrow = dim(y)[2], ncol = 1)
-      y <- y %*% wy
-    }
+    # If x or y is a matrix, get vector with row sums instead
+    if (is.matrix(x)) x <- rowSums(x)
+    if (is.matrix(y)) y <- rowSums(y)
 
-    xt <- paste('Inputs:\n', paste(input$dea.input, collapse = ', '))
-    yt <- paste('Outputs:\n', paste(input$dea.output, collapse = ', '))
-
-    p_ <- switch(
-      input$plot.rts,
-      'crs' = {
-        slope <- max(as.vector(y) / as.vector(x))
-        top <- max(as.vector(y) / slope)
-        coords <- list(x = c(0, top), y = c(0, top * slope))
-      },
-      'vrs' = {
-        hpts <- chull(unname(x), unname(y))
-        hpts <- hpts[c(which(x[hpts] == min(x[hpts])), which(head(x[hpts], -1) < tail(x[hpts], -1)) + 1)]
-
-        coords <- list(
-          x = c(min(x[hpts]), x[hpts], max(x[hpts])),
-          y = c(0, y[hpts], max(y[hpts])))
-      }
-    )
-
-    o <- paste0(
-      selection()[, input$dea.idvar], '\n',
-      'Efficiency score: ', round(dea.prod()$eff, 4), '\n',
-      'Combined inputs: ', round(as.vector(x), 4), '\n',
-      'Combined outputs: ', round(as.vector(y), 4)
-    )
-
-    p <- plot_ly(x = as.vector(x), y = as.vector(y), type = 'scatter', mode = 'markers',
-                 text = o, hoverinfo = 'text', source = 'deaplot', name = 'Units') %>%
-      layout(xaxis = list(title = xt, titlefont = list(size = 10)),
-             yaxis = list(title = yt, titlefont = list(size = 10)))
-
-    if (input$plot.rts %in% c('crs', 'vrs'))
-      p <- add_trace(p, x = coords$x, y = coords$y, type = 'scatter', mode = 'lines',
-                     text = 'Front', name = 'Front')
-
-    p
-
+    data.frame(dmu = rownames(dea.in()), x = unname(x), y = unname(y))
   })
+
+  dea_plot <- reactive({
+    req(data(), input$dea.input, input$dea.output)
+
+    d <- dea_plot_df()
+
+    p <- ggplot(d, aes(x = x, y = y)) +
+      geom_point(color = '#084887') +
+      xlab(paste('Inputs:\n', paste(input$dea.input, collapse = ', '))) +
+      ylab(paste('Outputs:\n', paste(input$dea.output, collapse = ', '))) +
+      scale_y_continuous(labels = label_number(suffix = find_scale(d$x)[[1]], scale = find_scale(d$x)[[2]])) +
+      scale_x_continuous(labels = label_number(suffix = find_scale(d$y)[[1]], scale = find_scale(d$y)[[2]])) +
+      theme_pioneer()
+
+    if (input$plot.rts %in% c('crs', 'vrs')) {
+      if (input$plot.rts == 'crs') {
+        p <- p + geom_abline(intercept = 0, slope = max(d$y/d$x), color = '#f9ab55')
+      } else if (input$plot.rts == 'vrs') {
+        hpts <- chull(d$x, d$y)
+        hpts <- hpts[c(which(d$x[hpts] == min(d$x[hpts])), which(head(d$x[hpts], -1) < tail(d$x[hpts], -1)) + 1)]
+
+        coords <- data.frame(
+          x = c(min(d$x[hpts]), d$x[hpts], max(d$x[hpts])),
+          y = c(0, d$y[hpts], max(d$y[hpts])))
+        p <- p + geom_line(data = coords, aes(x = x, y = y), color = '#f9ab55')
+      }
+    }
+
+    return(p)
+  })
+
+  output$plot_dea <- renderPlot({
+    p <- dea_plot()
+    p
+  })
+
+  output$plot_dea_tooltip <- renderUI({
+    x <- nearPoints(dea_plot_df(), input$dea_hover)
+    if (nrow(x) > 0) {
+      msg <- sprintf(
+        '<p class="p-1 m-0" style="font-size: .75rem">DMU: %s<br />Input: %s<br />Output: %s</p>',
+        x$dmu[1], x$x[1], x$y[1]
+      )
+      tags$div(class = 'alert alert-dark p-0 m-0', HTML(msg))
+    } else {
+      return()
+    }
+  })
+
+  output$dea.plot.save <- downloadHandler(
+    filename = function() {
+      sprintf('dea-plot-%s.%s', Sys.Date(), input$dea_dl_format)
+    },
+    content = function(file) {
+      ggsave_(
+        file, dea_plot(), format = tolower(input$dea_dl_format),
+        size = input$dea_dl_size)
+    }
+  )
 
   dea.scaleeff <- reactive({
 
@@ -334,12 +349,6 @@ shinyServer(function(input, output, session) {
 
   # ---- DEA output functions ----
 
-  output$plot.dea <- renderPlotly({
-
-    plot.dea()
-
-  })
-
   salterPlot <- reactive({
 
     d <- data.frame(
@@ -351,6 +360,7 @@ shinyServer(function(input, output, session) {
     )
 
     d <- d[order(d$eff),]
+    rownames(d) <- NULL
     d$w <- cumsum(d$inputs)
     d$wm <- d$w - d$inputs
     d$wt <- with(d, wm + (w - wm)/2)
@@ -363,32 +373,29 @@ shinyServer(function(input, output, session) {
 
     color <- sprintf('#%s', input$salter.color) # 'rgb(8,48,107)'
 
-    g <- ggplot(d, aes(x = wt, y = eff, width = inputs)) +
-      geom_bar(color = '#444444', fill = color,
-               stat = 'identity', position = 'identity') +
+    g <- ggplot(d, aes(x = wt, y = eff, width = inputs, fill = as.character(row.names(d)))) +
+      geom_bar(stat = 'identity', position = 'identity', show.legend = FALSE) +
+      scale_fill_manual(values = rep(c('#084887', '#f9ab55'), length.out = nrow(d))) +
       labs(x = input$salter.xtitle, y = input$salter.ytitle) +
-      theme_minimal()
+      scale_x_continuous(labels = label_number(suffix = find_scale(d$wt)[[1]], scale = find_scale(d$wt)[[2]])) +
+      scale_y_continuous(labels = label_number(suffix = find_scale(d$eff)[[1]], scale = find_scale(d$eff)[[2]])) +
+      theme_pioneer()
 
   })
 
-  output$dea.salter.plot <- renderPlotly({
-
+  output$dea_salter_plot <- renderPlot({
     g <- salterPlot()
-    ggplotly(g)
-
+    g
   })
 
   output$salter.save <- downloadHandler(
     filename = function() {
-      sprintf('salterplot-%s.%s', Sys.Date(), input$salter.format)
+      sprintf('salterplot-%s.%s', Sys.Date(), input$salter_dl_format)
     },
     content = function(file) {
-      dims <- switch (input$salter.size,
-                      A5 = c(210, 148),
-                      A4 = c(297, 210),
-                      A3 = c(420, 297)
-      )
-      ggsave(file, salterPlot(), width = dims[1], height = dims[2], units = 'mm')
+      ggsave_(
+        file, salterPlot(), format = tolower(input$salter_dl_format),
+        size = input$salter_dl_size)
     }
   )
 

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -1,5 +1,4 @@
 # Load required packages
-require(plotly)
 require(data.table)
 require(reactable)
 
@@ -131,25 +130,43 @@ ui <- function(request) { page_navbar(
             reactableOutput('dea.slack')
           ),
           tabPanel('Plot',
-                   plotlyOutput('plot.dea', height = 500),
+                   plotOutput('plot_dea', height = 600, hover = hoverOpts(
+                     id = 'dea_hover', delay = 100, delayType = 'throttle')
+                   ),
+                   uiOutput('plot_dea_tooltip'),
+                   div(
+                     dropdown_button(
+                       'Plot options', size = 'sm', color = 'light', autoclose = FALSE,
+                       textInput('dea_xtitle', 'X-axis title', 'Combined inputs'),
+                       textInput('dea_ytitle', 'Y-axis title', 'Efficiency'),
+                       selectizeInput('dea_dl_size', 'Image size', choices = c(
+                         'A5', 'A4', 'A3'
+                       )),
+                       selectizeInput('dea_dl_format', 'Image format', choices = c(
+                         'PNG' = 'png', 'PDF' = 'pdf'
+                       ))
+                     ),
+                     downloadButton('dea.plot.save', 'Save plot', class = 'btn-sm btn-light')
+                   ),
                    hr(),
+                   plotOutput('dea_salter_plot', height = 600, hover = hoverOpts(
+                     id = 'salter_hover', delay = 100, delayType = 'throttle')
+                   ),
                    div(
                      dropdown_button(
                        'Plot options', size = 'sm', color = 'light', autoclose = FALSE,
                        textInput('salter.color', 'Color', value = '85c9f7'),
                        textInput('salter.xtitle', 'X-axis title', 'Combined inputs'),
                        textInput('salter.ytitle', 'Y-axis title', 'Efficiency'),
-                       selectizeInput('salter.size', 'Image size', choices = c(
+                       selectizeInput('salter_dl_size', 'Image size', choices = c(
                          'A5', 'A4', 'A3'
-                       )
-                       ),
-                       selectizeInput('salter.format', 'Image format', choices = c(
+                       )),
+                       selectizeInput('salter_dl_format', 'Image format', choices = c(
                          'PNG' = 'png', 'PDF' = 'pdf'
                        ))
                      ),
-                     downloadButton('salter.save', 'Save plot', size = 'sm', color = 'light')
-                   ),
-                   plotlyOutput('dea.salter.plot', height = 500)
+                     downloadButton('salter.save', 'Save plot', class = 'btn-sm btn-light')
+                   )
           ),
           tabPanel(
             'Peers',

--- a/inst/app/www/pioneer.js
+++ b/inst/app/www/pioneer.js
@@ -11,6 +11,29 @@ $(document).ready(function() {
     }
   });
 
+  $('#plot_dea').mousemove(function(e) {
+    // Use scrollWidth and scrollHeight on the html element to get document width and height
+    let el = document.getElementById('plot_dea_tooltip');
+    let docX = document.documentElement.scrollWidth;
+    let docY = document.documentElement.scrollHeight;
+    // If we are far from the right edge, position with left, else position with right
+    if ((docX - e.pageX) > 200) {
+      el.style.left = (e.pageX + 5) + "px";
+      el.style.right = null;
+    } else {
+      el.style.left = null;
+      el.style.right = (docX - e.pageX + 5) + "px";
+    }
+    // If we are far from the bottom, position with top, else position with bottom
+    if ((docY - e.pageY) > 200) {
+      el.style.top = (e.pageY + 5) + "px";
+      el.style.bottom = null;
+    } else {
+      el.style.top = null;
+      el.style.bottom = (docY - e.pageY + 5) + "px";
+    }
+  });
+
   $(document).on('shiny:inputchanged', function(e) {
     if (e.name === 'hasyear') {
       let el_m = document.querySelector('[data-value="malmquist"]').closest('li');

--- a/inst/app/www/style.css
+++ b/inst/app/www/style.css
@@ -32,3 +32,10 @@ h2 {
 .input-group-btn {
   width: auto;
 }
+
+#plot_dea_tooltip {
+  position: absolute;
+  width: auto;
+  z-index: 9999;
+  padding: 0;
+}


### PR DESCRIPTION
This PR replaces the plotly plots from the app with ggplot2 versions. Since ggplot2 is not interactive with tooltips as a default, this behavior has been retooled with observe functions and JavaScript. Since the plots are now done entirely with ggplot2, it is also possible to download them. Hvis PR should still be considered a draft, but it should (hopefully) be possible to merge without too much work.