### PR TITLE
6 include dea bootstrapping

### DIFF
--- a/inst/app/R/fct_dea-boostrap.R
+++ b/inst/app/R/fct_dea-boostrap.R
@@ -1,0 +1,94 @@
+bw_rule <- function(delta, rule = 'cv', adjust = TRUE, type = NULL) {
+  bw_rule <- 3
+  if (is.character(rule)) {
+    bw_rule <- switch(rule,
+                      'silverman' = 1,
+                      'scott' = 2,
+                      'cv' = 3,
+                      'sw98' = 4,
+                      3
+    )
+    if (is.null(bw_rule)) {
+      cli::cli_warn('Unknown bandwidth rule. Using default value instead')
+    }
+  } else if (is.numeric(rule)) {
+    if (rule %in% 1:3) {
+      bw_rule <- rule
+    } else {
+      cli::cli_warn('Unknown bandwidth rule. Using default value instead')
+    }
+  } else {
+    cli::cli_warn('Unknown bandwidth rule. Using default value instead')
+  }
+  # Values must be in range 1, Inf. Take inverse if values are in range 0, 1
+  if (min(delta) < 1) {
+    delta <- 1/delta
+  }
+  # Values == 1 are artifacts of DEA method and should be removed for h
+  delta_m <- delta[delta > 1]
+  delta_2m <- c(delta_m, 2 - delta_m)
+  if (bw_rule == 1) {
+    h <- bw.nrd0(delta_2m)
+  } else if (bw_rule == 2) {
+    h <- bw.nrd(delta_2m)
+  } else if (bw_rule == 3) {
+    suppressWarnings({ h <- bw.ucv(delta_2m) })
+  } else if (bw_rule == 4) {
+    return(0.014)
+  }
+  if (adjust) {
+    h <- h * 2^(1/5) * (length(delta_m)/length(delta))^(1/5) * (sd(delta)/sd(delta_2m))
+  }
+  h
+}
+
+bootstrap_sample <- function(delta, h, n = length(delta)) {
+  # Values must be in range 1, Inf. Take inverse if values are in range 0, 1
+  if (min(delta) < 1) {
+    delta <- 1/delta
+  }
+  delta_2m <- c(delta, 2 - delta)
+  beta <- sample(delta_2m, n, replace = TRUE)
+  # See Simar & Wilson (1998), eq. 4.20
+  beta <- beta + h * rnorm(n)
+  beta[beta < 1] <- 2 - beta[beta < 1]
+  # See Simar & Wilson (1998), eq. 4.25
+  beta <- mean(delta) + 1/sqrt(1 + h^2/var(delta)) * (beta - mean(delta))
+  # Return beta values from bootstrap sample
+  1/beta
+}
+
+perform_boot <- function(x, y, rts, orientation, i, h, theta, boot) {
+  beta <- bootstrap_sample(theta, h = h)
+  if (orientation == 'in') {
+    x_ref <- (theta / beta) * x
+    boot[, i] <- Benchmarking::dea(x, y, RTS = rts, ORIENTATION = orientation, XREF = x_ref, FAST = TRUE)
+  } else if (orientation == 'out') {
+    beta <- 1 / beta
+    y_ref <- (theta / beta) * y
+    boot[, i] <- Benchmarking::dea(x, y, RTS = rts, ORIENTATION = orientation, YREF = y_ref, FAST = TRUE)
+  }
+  return(invisible(boot))
+}
+
+process_boot <- function(rts, orientation, h, alpha, theta, boot) {
+  # Correcting for bias and constructing CI based on SW98, eq. 2.17 and 2.18
+  bias <- as.vector(rowMeans(boot) - theta)
+  theta_tilde <- theta - bias
+  theta_ci <- t(apply(boot, 1, quantile, probs = c(alpha / 2, 1 - alpha / 2))) - (2 * bias)
+  # Return data
+  out <- list(
+    eff = theta,
+    bias = bias,
+    eff_bc = theta_tilde,
+    ci = theta_ci,
+    tbl = data.frame(
+      eff = theta,
+      bias = bias,
+      eff_bc = theta_tilde,
+      lower = as.vector(theta_ci[, 1]),
+      upper = as.vector(theta_ci[, 2])
+    )
+  )
+  invisible(out)
+}

--- a/inst/app/server.R
+++ b/inst/app/server.R
@@ -938,6 +938,20 @@ shinyServer(function(input, output, session) {
     res
   })
 
+  output$boot_rts_warn <- renderUI({
+    req(model_params$rts)
+    if (!model_params$rts %in% c('crs', 'vrs')) {
+      session$sendCustomMessage('disable_run_bootstrap', TRUE)
+      return(p(
+        class = 'small text-danger',
+        'Bootstrap is only supported with constant or variable returns to scale.'
+      ))
+    } else {
+      session$sendCustomMessage('disable_run_bootstrap', FALSE)
+      return()
+    }
+  })
+
   output$boot_tbl <- renderUI({
 
     rts <- model_params$rts

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -63,8 +63,8 @@ ui <- function(request) { page_navbar(
     sidebarLayout(
       sidebarPanel(
         width = 3,
-        selectInput('plot.rts', 'Returns to Scale', choices = vals$rts, selected = 'crs'),
-        selectInput('plot.orientation', 'Orientation', choices = vals$orient, selected = 'in'),
+        selectInput('dea_rts', 'Returns to Scale', choices = vals$rts, selected = 'crs'),
+        selectInput('dea_orientation', 'Orientation', choices = vals$orient, selected = 'in'),
         checkboxInput('dea.norm', 'Normalize input/output', value = FALSE),
         p(strong('Output options')),
         checkboxInput('out.slack', 'Show slack', value = TRUE),

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -1,8 +1,11 @@
 # Load required packages
 require(data.table)
 require(reactable)
+require(bslib)
 
 ver <- utils::packageVersion('pioneeR')
+
+sidebar_width <- 400
 
 vals <- list(
   'rts' = c(
@@ -167,6 +170,59 @@ ui <- function(request) { page_navbar(
           )
         )
       )
+    )
+  ),
+
+  tabPanel(
+    title = 'Bootstrap',
+    value = 'bootstrap',
+    layout_sidebar(
+      sidebar = sidebar(
+        width = sidebar_width,
+        accordion(
+          open = NULL, multiple = TRUE, class = 'mb-2',
+          accordion_panel(
+            'Bootstrap options',
+            selectizeInput(
+              'boot_rts', 'Returns to scale', choices = vals$rts, selected = 'crs'
+            ),
+            uiOutput('boot_rts_warn'),
+            selectInput(
+              'boot_orientation', 'Orientation', choices = vals$orient,
+              selected = 'in'
+            ),
+            selectizeInput(
+              'boot_alpha',
+              'Alpha',
+              choices = c('1 %' = 0.01, '5 %' = 0.05, '10 %' = 0.1),
+              selected = 0.05
+            ),
+            numericInput('boot_b', 'Iterations', min = 20, max = 5000, step = 1, value = 200)
+          ),
+          accordion_panel(
+            'Advanced options',
+            selectizeInput(
+              'boot_bw',
+              'Bandwidth selection',
+              choices = c(
+                'Silverman\'s rule of thumb' = 'silverman',
+                'Robust normal rule (Scott)' = 'scott',
+                'Unbiased cross validation' = 'ucv',
+                'sw98'),
+              selected = 'ucv'
+            )
+          ),
+          accordion_panel(
+            'Table options',
+            numericInput('boot_round', 'Number of decimals', min = 1L, max = 15L, step = 1L, value = 4L),
+            checkboxInput('boot_show_eff', 'Show original efficiency score', value = TRUE),
+            checkboxInput('boot_show_bias', 'Show bias', value = FALSE)
+          )
+        ),
+        actionButton('run_boot', 'Run bootstrap', class = 'btn-primary btn-sm')
+      ),
+      div(class = 'alert alert-info', role = 'alert', 'Bootstrap functionality is currently in preview'),
+      uiOutput('boot_tbl')
     )
   ),
 

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -73,7 +73,7 @@ ui <- function(request) { page_navbar(
         actionButton('delete_all_models', 'Delete all models'),
         uiOutput('saved_models_info'),
         hr(),
-        numericInput('out.decimals', 'Number of decimals', min = 2, max = 10, step = 1, value = 5),
+        numericInput('dea_round', 'Number of decimals', min = 1L, max = 15L, step = 1L, value = 4L),
         radioButtons(
           'show.in', 'Show inputs', choices = c('None' = 'none', 'All' = 'all', 'Combined' = 'comb'),
           selected = 'none', inline = TRUE),
@@ -216,7 +216,7 @@ ui <- function(request) { page_navbar(
     )
   ),
 
-  footer = div( class = 'small text-center', tagList(
+  footer = div(class = 'small text-center', tagList(
     hr(),
     p('Developed by the Data Science team at the Office of the Auditor General of Norway.'),
     p(HTML(sprintf('&copy; %s Riksrevisjonen. Version %s', format(Sys.Date(), '%Y'), ver)))

--- a/inst/app/www/pioneer.js
+++ b/inst/app/www/pioneer.js
@@ -2,9 +2,11 @@
 
 $(document).ready(function() {
 
-  document.querySelector('[data-value="malmquist"]').closest('li').style.display = 'none';
-  document.querySelector('[data-value="pioneeranalysis"]').closest('li').style.display = 'none';
-  document.querySelector('[data-value="pioneer_compare"]').closest('li').style.display = 'none';
+  let hiddenTabs = ['pioneeranalysis', 'bootstrap', 'malmquist', 'pioneer_compare'];
+  for (let i = 0; i < hiddenTabs.length; i++) {
+    console.log(`[data-value="${hiddenTabs[i]}"]`);
+    document.querySelector(`[data-value="${hiddenTabs[i]}"]`).closest('li').style.display = 'none';
+  }
 
   document.addEventListener('click', function(e) {
     if (e.target.id === 'uopts_menu') {
@@ -59,12 +61,15 @@ $(document).ready(function() {
     if (e.name === 'hasyear') {
       let el_m = document.querySelector('[data-value="malmquist"]').closest('li');
       let el_a = document.querySelector('[data-value="pioneeranalysis"]').closest('li');
+      let el_b = document.querySelector('[data-value="bootstrap"]').closest('li');
       if (e.value === true) {
         el_m.style.display = 'block';
         el_a.style.display = 'none';
+        el_b.style.display = 'none';
       } else if (e.value === false) {
         el_m.style.display = 'none';
         el_a.style.display = 'block';
+        el_b.style.display = 'block';
       }
     }
   });

--- a/inst/app/www/pioneer.js
+++ b/inst/app/www/pioneer.js
@@ -50,6 +50,15 @@ $(document).ready(function() {
     el.style.display = msg === true ? 'block' : 'none';
   });
 
+  Shiny.addCustomMessageHandler('disable_run_bootstrap', function(msg) {
+    let el = document.getElementById('run_boot');
+    if (msg === true) {
+      el.setAttribute('disabled', '');
+    } else {
+      el.removeAttribute('disabled');
+    }
+  });
+
   $(document).on('click', '[data-app-delete-id]', function(e) {
     let id = e.target.getAttribute('data-app-delete-id');
     let parent = e.target.closest('div.row');


### PR DESCRIPTION
This is a first stab at adding bootstrap functionality to close #6. This PR also closes #47. The bootstrap functionality is based on Simar and Wilson (1998) and Daraio and Wilson (2007). The bootstrap functions have been tested against `dea.boot` in Benchmarking and `dea.robust` in rDEA. These packages differ substantially, and we have therefore chosen methods and algorithms that more closely aligns with the results presented in Simar and Wilson (1998). By default bootstrap iterations will be performed using the method described by Simar and Wilson, with more detailed equations in Daraio and Wilson. For the kernel density estimation, the bandwidth value is chosen using unbiased cross validation, and adjusted according to Daraio and Wilson. With the default settings, the bootstrap function in pioneeR will differ from both Benchmarking and rDEA, but will more closely follow the results in Simar and Wilson. This can be tested with the dataset `Electric_plants` from the deaR package, ie. `run_pioneer(x = deaR::Electric_plants)`.

Note that currently, the user cannot export results from the bootstrap, nor save the results to the active R session. This should be added with another issue/PR.