### PR TITLE
Add fix for missing bootstraped values, and warn user if any

### DIFF
--- a/inst/app/R/fct_dea-boostrap.R
+++ b/inst/app/R/fct_dea-boostrap.R
@@ -49,15 +49,19 @@ perform_boot <- function(x, y, rts, orientation, i, h, theta, boot) {
 
 process_boot <- function(rts, orientation, h, alpha, theta, boot) {
   # Correcting for bias and constructing CI based on SW98, eq. 2.17 and 2.18
-  bias <- as.vector(rowMeans(boot) - theta)
+  bias <- as.vector(rowMeans(boot, na.rm = TRUE) - theta)
   theta_tilde <- theta - bias
-  theta_ci <- t(apply(boot, 1, quantile, probs = c(alpha / 2, 1 - alpha / 2))) - (2 * bias)
+  theta_ci <- t(apply(boot, 1, quantile, probs = c(alpha / 2, 1 - alpha / 2), na.rm = TRUE)) - (2 * bias)
+  # Check for missingness
+  is_missing <- apply(boot, 1, \(x) any(is.na(x)))
+
   # Return data
   out <- list(
     eff = theta,
     bias = bias,
     eff_bc = theta_tilde,
     ci = theta_ci,
+    missing = if (all(!is_missing)) NULL else which(is_missing),
     tbl = data.frame(
       eff = theta,
       bias = bias,

--- a/inst/app/server.R
+++ b/inst/app/server.R
@@ -968,7 +968,7 @@ shinyServer(function(input, output, session) {
     # Add DMU names and round inputs
     df <- cbind(data.frame(DMU = names(dea.prod()$eff)), round(res$tbl, input$boot_round))
 
-    reactable(
+    tbl <- reactable(
       df,
       class = 'small',
       striped = TRUE,
@@ -982,6 +982,23 @@ shinyServer(function(input, output, session) {
         upper = colDef(name = 'Upper bound')
       )
     )
+
+    # Add warning if there are any missing observations
+    if (!is.null(res$missing)) {
+      tagList(
+        div(
+          class = 'alert alert-warning', sprintf(
+            'Units with indices %s had one or more missing bootstrapped efficiency
+            scores. Bias and confidence intervals have been estimated on the available
+            values.',
+            paste(res$missing, collapse = ', ')
+          )
+        ),
+        tbl
+      )
+    } else {
+      tbl
+    }
   })
 
   # ---- Malmquist ----


### PR DESCRIPTION
Should fix error as described in #54. Tested with data set from Warsaw course which will fail under certain conditions with missing values for one or more units in the bootstrapped values.