### PR TITLE
Hotfix for bug as reported in #98.

### DIFF
--- a/R/server.R
+++ b/R/server.R
@@ -674,13 +674,16 @@ server <- function(input, output, session) {
     mod_save <- list(
       id = rand_id(),
       data = data.frame(
-        idx = seq_len(length(mod$values)),
-        dmu = selection()[, input$dea_id], #names(mod$eff),
+        idx = seq_along(mod$values),
+        dmu = selection()[, input$dea_id],
         eff = round(unname(mod$values), input$dea_round)
       ),
+      # We currently use the reactive model values from the app state to record
+      # model params. However, we should create a model object as we do in compute_dea()
+      # and return this object with attributes instead.
       params = list(
-        rts = mod$RTS,
-        orientation = mod$ORIENTATION
+        rts = model_params$rts,
+        orientation = model_params$orientation
       )
     )
     models(append(models(), list(mod_save)))


### PR DESCRIPTION
The PR should close the bug as reported in #98 where the Compare tab will fail because of `NULL` values in the model parameters. While this PR restores the compare-functionality, it is not the optimal solution. A better long term solution is to record and return S3-objects in the same way as the exported `compare_dea()` function. This will also make it easier for the user to work with the object that is returned from the app. See #95 for a description of a long term solution.