### PR TITLE
83 add warning if the power of the analysis is low

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pioneeR
 Title: Perform productivity analyses in a web browser
-Version: 0.4.0
+Version: 0.4.0.9000
 Authors@R: c(
     person("Ove Haugland", "Jakobsen", role = c("aut", "cre"), email = "ohj@mac.com"),
     person("Aleksander", "Eilertsen", role = "aut", email = "ale@riksrevisjonen.no"),
@@ -18,6 +18,7 @@ Depends:
     shiny (>= 1.7.0)
 Imports:
     bslib (>= 0.6.0),
+    bsicons,
     cli (>= 3.6.0),
     ggplot2 (>= 3.3.0),
     haven (>= 2.5.0),

--- a/R/dea-utils.R
+++ b/R/dea-utils.R
@@ -150,6 +150,13 @@ check_nunits <- function(x, y, ref = FALSE) {
     }
     cli::cli_abort(c('Inconsistent number of units: ', 'x' = msg))
   }
+  if (nx < (ncol(x) * ncol(y)) || nx < (ncol(x) + ncol(y)) * 3) {
+    cli::cli_warn(
+      "The number of DMUs ({nx}) is lower than the recommended minimum. Consider adding more
+      DMUs. You should have at least {max(c(ncol(x) * ncol(y), (ncol(x) + ncol(y)) * 3))}
+      DMUs based on the number of inputs and outputs."
+    )
+  }
 }
 
 #' round_numeric

--- a/R/shiny-functions.R
+++ b/R/shiny-functions.R
@@ -101,22 +101,22 @@ check_balance <- function(data, id_var, time_var) {
 #' @param level Level of alert
 #' @param message The message to show the user
 #' @param object A reactive object to update
-#' @param append Boolean. If the message should be appended to the reative
+#' @param append Boolean. If the message should be appended to the reactive
 #' @noRd
 set_message <- function(level, message, object = NULL, append = FALSE) {
   classes <- switch(
     level,
-    warning = 'alert alert-warning',
-    error = 'alert alert-danger',
-    'alert alert-info'
+    warning = "alert alert-warning",
+    error = "alert alert-danger",
+    "alert alert-info"
   )
-  icon <- if (level == 'info') 'info-circle' else 'exclamation-circle'
-  div <- div(class = classes, list(bsicons::bs_icon(icon, class = 'me-2'), message))
+  icon <- if (level == "info") "info-circle" else "exclamation-circle"
+  div <- div(class = classes, list(bsicons::bs_icon(icon, class = "me-2"), message))
   # If we do not have a reactive, return the div
   if (is.null(object)) {
     return(div)
   }
-  # If we have a reactive object, set or append our div to the reative
+  # If we have a reactive object, set or append our div to the reactive
   if (append) {
     current_tags <- object()
     object(tagList(current_tags, div))
@@ -130,11 +130,11 @@ set_message <- function(level, message, object = NULL, append = FALSE) {
 #' the user
 #' @noRd
 catch_warnings <- function(expr, handler_expr, reactive, append = FALSE) {
-  if (shiny::isRunning() || as.logical(Sys.getenv('PIONEER_SUPPRESS_WARNINGS', FALSE))) {
+  if (shiny::isRunning() || as.logical(Sys.getenv("PIONEER_SUPPRESS_WARNINGS", FALSE))) {
     withCallingHandlers(expr, warning = \(w) {
       msg <- if (inherits(w, "rlang_warning")) cli::ansi_strip(w$message) else conditionMessage(w)
-      handler_expr('warning', msg, reactive)
-      tryInvokeRestart('muffleWarning')
+      handler_expr("warning", msg, reactive)
+      tryInvokeRestart("muffleWarning")
     })
   } else {
     expr
@@ -149,7 +149,7 @@ catch_exceptions <- function(expr, handler_expr, reactive, append = FALSE) {
   if (shiny::isRunning()) {
     tryCatch(catch_warnings(expr, handler_expr, reactive), error = \(e) {
       msg <- if (inherits(e, "rlang_error")) cli::ansi_strip(e$message) else conditionMessage(e)
-      handler_expr('error', msg, reactive)
+      handler_expr("error", msg, reactive)
       NULL
     })
   } else {

--- a/R/ui.R
+++ b/R/ui.R
@@ -56,6 +56,7 @@ ui <- function(request) { page_navbar(
           'and that states might be deleted by the server administrator.'
         )))
       ),
+      uiOutput('preview_messages'),
       uiOutput('data_preview')
     )
   ),

--- a/tests/testthat/test-dea-utils.R
+++ b/tests/testthat/test-dea-utils.R
@@ -43,13 +43,18 @@ test_that('check_numeric() works correctly', {
 
 test_that('check_nunits() works correctly', {
   # correct
-  x <- data.frame(a = c(1, 2, 3), b = c(4, 5, 6))
-  y <- data.frame(c = c(7, 8, 9), d = c(10, 11, 12))
+  x <- data.frame(a = 1:12, b = 13:24)
+  y <- data.frame(c = 25:36, d = 37:48)
   expect_silent(check_nunits(x, y))
 
   # incorrect
   x <- data.frame(a = c(1, 2, 3), b = c(4, 5, 6))
   y <- data.frame(c = c(7, 8, 9, 10), d = c(11, 12, 13, 14))
   expect_error(check_nunits(x, y))
+
+  # to few DMUs
+  x <- data.frame(a = c(1, 2, 3), b = c(4, 5, 6))
+  y <- data.frame(c = c(7, 8, 9), d = c(10, 11, 12))
+  expect_warning(check_nunits(x, y))
 })
 

--- a/tests/testthat/test-shiny-functions.R
+++ b/tests/testthat/test-shiny-functions.R
@@ -1,7 +1,26 @@
-Sys.unsetenv('PIONEER_DATA')
+Sys.unsetenv("PIONEER_DATA")
 
-test_that('unsetting environment variables works', {
-  Sys.setenv(PIONEER_DATA = 'hello world')
+test_that("unsetting environment variables works", {
+  Sys.setenv(PIONEER_DATA = "hello world")
   unset_env_vars()
-  expect_false(nzchar(Sys.getenv('PIONEER_DATA')))
+  expect_false(nzchar(Sys.getenv("PIONEER_DATA")))
+})
+
+test_that("check_balance() works as expected", {
+  # balanced
+  df <- data.frame(id = rep(LETTERS[1:6], 2), time = c(rep.int(1984, 6), rep.int(2001, 6)))
+  expect_false(check_balance(df, "id", "time")$listwise)
+
+  # unbalanced
+  df <- data.frame(id = c(LETTERS[1:6], LETTERS[1:5]), time = c(rep.int(1984, 6), rep.int(2001, 5)))
+  expect_true(check_balance(df, "id", "time")$listwise)
+})
+
+test_that("set_message() returns a div", {
+  div <- set_message("warning", "A warning")
+  expect_equal(class(div), "shiny.tag")
+  expect_equal(div$attribs$class, "alert alert-warning")
+  div <- set_message("info", "An ordinary message")
+  expect_equal(class(div), "shiny.tag")
+  expect_equal(div$attribs$class, "alert alert-info")
 })


### PR DESCRIPTION
This PR adds helper functions to catch warnings and errors from function calls and display them to the user. These functions are used to implement a solution for #83 in order to warn the user that the power of the analysis is low. The test for power itself is implemented in the function `check_nunits()` so that users that use R will also see the warning message as an ordinary warning printed to the console.