### PR TITLE
88 add caching to app

### DIFF
--- a/R/shiny-functions.R
+++ b/R/shiny-functions.R
@@ -60,7 +60,10 @@ run_pioneer <- function(x = NULL, port = NULL, ...) {
 
 #' @rdname run_pioneer
 #' @export
-runPioneeR <- run_pioneer
+runPioneeR <- function(x = NULL, port = NULL, ...) {
+  deprecation_warning(alternative = "run_pioneeR", next_release = TRUE)
+  run_pioneer(x = x, port = port, ...)
+}
 
 #' Unset environment variables
 #'

--- a/R/ui.R
+++ b/R/ui.R
@@ -235,7 +235,8 @@ ui <- function(request) { page_navbar(
               choices = c('Excel' = 'xlsx', 'Stata' = 'dta', 'Comma separated values' = 'csv'))
           )
         ),
-        actionButton('run_boot', 'Run bootstrap', class = 'btn-primary btn-sm')
+        actionButton("run_boot", "Run bootstrap", class = "btn-primary btn-sm mb-2"),
+        actionButton("clear_boot_cache", "Clear cache", class = "btn-warning btn-sm")
       ),
       div(class = 'alert alert-info', role = 'alert', 'Bootstrap functionality is currently in preview'),
       uiOutput('boot_tbl')

--- a/R/utils.R
+++ b/R/utils.R
@@ -125,3 +125,23 @@ round_numeric <- function(df, digits) {
   df[] <- lapply(df, function(x) if(is.numeric(x)) round(x, digits) else x)
   df
 }
+
+#' @param alternative An alternative function the user should migrate to
+#' @param next_release If the function will be removed in the next release
+#' @noRd
+deprecation_warning <- function(alternative = NULL, next_release = FALSE) {
+  caller <- as.character(sys.call(-1)[[1]])
+  when <- if (next_release) "the next release" else "a future release"
+  if (!is.null(alternative) && is.character(alternative)) {
+    cli::cli_warn(sprintf(
+      "%s() has been deprecated and will be removed in %s. Use %s() instead",
+      caller, when, alternative
+    ))
+  } else {
+    cli::cli_warn(sprintf(
+      "%s() has been deprecated and will be removed in %s.",
+      caller, when
+    ))
+  }
+  invisible()
+}


### PR DESCRIPTION
This PR closes #85 and #88 by adding caching in the Shiny app, which most users will use. One downside with caching bootstrapped results, is that this masks the inherent stochastic nature of the bootstrap, as values will stay the same for each model. I've therefore added a way to clear the cache by setting a random cache key that the `bindCache()` function depends on.

I need a second opinion on the implementation before I finish this PR and (possible) extend the caching technique to other model reactive as well.